### PR TITLE
fix: remove duplicate word in features copy

### DIFF
--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -41,7 +41,7 @@ export function Features() {
           Everything you need to deploy your app
         </p>
         <p className="mt-6 text-lg/8 text-gray-700 dark:text-gray-300">
-          Quis tellus eget adipiscing convallis sit sit eget aliquet quis. Suspendisse eget egestas a elementum
+          Quis tellus eget adipiscing convallis sit eget aliquet quis. Suspendisse eget egestas a elementum
           pulvinar et feugiat blandit at. In mi viverra elit nunc.
         </p>
       </div>


### PR DESCRIPTION
## Summary
- fix repeated "sit" in features copy

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac76eacea4832489aa53705c46cd87