### PR TITLE
refactor: use shared prisma instance in dynasty utils

### DIFF
--- a/src/lib/dynasty/utils.ts
+++ b/src/lib/dynasty/utils.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "../prisma";
 
 export async function getDynastyValues(playerIds: string[]) {
   if (playerIds.length === 0) return new Map();


### PR DESCRIPTION
## Summary
- use shared `prisma` instance in dynasty utils

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac76e5ac98832480f30ed24b030d43