### PR TITLE
docs: note display-name match fallback for team lookup

### DIFF
--- a/src/app/dashboard/league/[id]/page.tsx
+++ b/src/app/dashboard/league/[id]/page.tsx
@@ -317,7 +317,8 @@ export default function LeaguePage() {
     </div>
   )
 
-  // Get current user's team by matching the owner username with the default saved account
+  // Get current user's team by matching the default saved account to a roster owner.
+  // Handles missing usernames by attempting a display_name match before falling back to username
   const getMyTeam = () => {
     if (!leagueData?.rosters || leagueData.rosters.length === 0) return null
     


### PR DESCRIPTION
## Summary
- clarify getMyTeam comment to document display-name match when usernames are missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac7692212883249d766a0585add03f