### PR TITLE
feat: add reusable input and button components

### DIFF
--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import Image from "next/image"
+import { Input, Button } from "@/components"
 
 export default function SignIn() {
   const [email, setEmail] = useState("")
@@ -97,7 +98,7 @@ export default function SignIn() {
                 Email address
               </label>
               <div className="mt-2">
-                <input
+                <Input
                   id="email"
                   name="email"
                   type="email"
@@ -106,7 +107,6 @@ export default function SignIn() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   disabled={isLoading}
-                  className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 />
               </div>
             </div>
@@ -126,7 +126,7 @@ export default function SignIn() {
                 </div>
               </div>
               <div className="mt-2">
-                <input
+                <Input
                   id="password"
                   name="password"
                   type="password"
@@ -135,19 +135,14 @@ export default function SignIn() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   disabled={isLoading}
-                  className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 />
               </div>
             </div>
 
             <div>
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm/6 font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button type="submit" disabled={isLoading}>
                 {isLoading ? "Signing in..." : "Sign in"}
-              </button>
+              </Button>
             </div>
           </form>
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
 import Link from "next/link"
 import Image from "next/image"
+import { Input, Button } from "@/components"
 
 export default function SignUp() {
   const [email, setEmail] = useState("")
@@ -106,7 +107,7 @@ export default function SignUp() {
                 Full Name (Optional)
               </label>
               <div className="mt-2">
-                <input
+                <Input
                   id="name"
                   name="name"
                   type="text"
@@ -114,7 +115,6 @@ export default function SignUp() {
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   disabled={isLoading}
-                  className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 />
               </div>
             </div>
@@ -124,7 +124,7 @@ export default function SignUp() {
                 Email address
               </label>
               <div className="mt-2">
-                <input
+                <Input
                   id="email"
                   name="email"
                   type="email"
@@ -133,7 +133,6 @@ export default function SignUp() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   disabled={isLoading}
-                  className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 />
               </div>
             </div>
@@ -143,7 +142,7 @@ export default function SignUp() {
                 Password
               </label>
               <div className="mt-2">
-                <input
+                <Input
                   id="password"
                   name="password"
                   type="password"
@@ -152,19 +151,14 @@ export default function SignUp() {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   disabled={isLoading}
-                  className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 />
               </div>
             </div>
 
             <div>
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm/6 font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button type="submit" disabled={isLoading}>
                 {isLoading ? "Creating account..." : "Create account"}
-              </button>
+              </Button>
             </div>
           </form>
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,3 +9,5 @@ export { CTA } from './CTA'
 export { Footer } from './Footer'
 
 
+export { Input } from './ui/Input'
+export { Button } from './ui/Button'

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,17 @@
+import clsx from 'clsx'
+import React from 'react'
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>
+
+export function Button({ className, disabled, ...props }: ButtonProps) {
+  return (
+    <button
+      {...props}
+      disabled={disabled}
+      className={clsx(
+        'flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm/6 font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed',
+        className
+      )}
+    />
+  )
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,17 @@
+import clsx from 'clsx'
+import React from 'react'
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+export function Input({ className, disabled, ...props }: InputProps) {
+  return (
+    <input
+      {...props}
+      disabled={disabled}
+      className={clsx(
+        'block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed',
+        className
+      )}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- add generic Input and Button components with shared styling
- export new UI components from central index
- update sign-in and sign-up pages to use new UI components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac8a0a239c832489ed7766d7f7c899