### PR TITLE
chore: add tailwind config

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,7 @@
+import tailwindcss from "@tailwindcss/postcss";
+
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: [tailwindcss({ config: "./tailwind.config.ts" })],
 };
 
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,34 @@
+import type { Config } from "tailwindcss";
+import defaultTheme from "tailwindcss/defaultTheme";
+
+const config: Config = {
+  content: ["./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        card: "var(--card)",
+        "card-foreground": "var(--card-foreground)",
+        muted: "var(--muted)",
+        "muted-foreground": "var(--muted-foreground)",
+        accent: "var(--accent)",
+        "accent-foreground": "var(--accent-foreground)",
+        border: "var(--border)",
+        input: "var(--input)",
+        ring: "var(--ring)",
+      },
+      fontFamily: {
+        sans: ["Inter", ...defaultTheme.fontFamily.sans],
+        serif: ["Merriweather", ...defaultTheme.fontFamily.serif],
+      },
+      spacing: {
+        128: "32rem",
+        144: "36rem",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add Tailwind configuration with content paths, theme color variables, fonts, and spacing
- update PostCSS setup to reference the new Tailwind config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac8a5ac5488324a6a9ffd370b9e560