### PR TITLE
feat: add theme provider with next-themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "framer-motion": "^12.23.12",
         "next": "15.5.0",
         "next-auth": "^4.24.11",
+        "next-themes": "^0.4.6",
         "openai": "^5.15.0",
         "postcss": "^8.5.6",
         "react": "19.1.0",
@@ -4988,6 +4989,16 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "framer-motion": "^12.23.12",
     "next": "15.5.0",
     "next-auth": "^4.24.11",
+    "next-themes": "^0.4.6",
     "openai": "^5.15.0",
     "postcss": "^8.5.6",
     "react": "19.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" suppressHydrationWarning>
       <body
         className="antialiased"
       >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useSession, signOut } from 'next-auth/react'
+import { useTheme } from 'next-themes'
 import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react'
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 import Image from 'next/image'
@@ -17,6 +18,7 @@ export function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const { status } = useSession()
   const isAuthenticated = status === 'authenticated'
+  const { theme, setTheme } = useTheme()
 
   const handleAuthAction = () => {
     if (isAuthenticated) {
@@ -64,6 +66,12 @@ export function Header() {
           ))}
         </div>
         <div className="hidden lg:flex lg:flex-1 lg:justify-end lg:gap-x-6">
+          <button
+            onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+          >
+            Toggle theme
+          </button>
           {isAuthenticated && (
             <a href="/dashboard" className="text-sm/6 font-semibold text-gray-900 dark:text-white hover:text-gray-700 dark:hover:text-gray-300">
               Dashboard
@@ -142,6 +150,12 @@ export function Header() {
                 )}
               </div>
               <div className="py-6">
+                <button
+                  onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+                  className="-mx-3 mb-2 block rounded-lg px-3 py-2.5 text-base/7 font-semibold text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-white/5 w-full text-left"
+                >
+                  Toggle theme
+                </button>
                 {isAuthenticated ? (
                   <button
                     onClick={handleAuthAction}

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,11 +1,15 @@
 "use client"
 
 import { SessionProvider } from "next-auth/react"
+import { ThemeProvider } from "./theme-provider"
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <SessionProvider>
-      {children}
-    </SessionProvider>
+    <ThemeProvider>
+      <SessionProvider>
+        {children}
+      </SessionProvider>
+    </ThemeProvider>
   )
 }
+

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes"
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="dark" {...props}>
+      {children}
+    </NextThemesProvider>
+  )
+}
+


### PR DESCRIPTION
## Summary
- install and configure next-themes
- wrap app with custom ThemeProvider and add theme toggle to header
- manage html class via next-themes instead of hard-coded dark mode

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac8a5d6fc48324868d2720704491db