### PR TITLE
Simplify dynasty value scoring to market and age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Generic Player Page**: Created placeholder player page with "Coming Soon" message for future player details functionality
 
 ### Changed
-- **Dynasty Value Formula**: Removed risk score, updated weights to Market (50%), Projection (25%), Age (25%)
-- **ADP Normalization**: Changed from position-based to global ADP normalization
+- **Dynasty Value Formula**: Removed projection and risk scores; weights now Market (75%) and Age (25%)
+- **ADP Normalization**: Switched to logistic scaling to reduce score saturation
 - **UI Restructuring**: Removed standalone dynasty values and assistant pages from dashboard
 - **Chat Component Styling**: Streamlined chat interface with mobile-first design, removed header and borders
 
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Type Errors**: Resolved TypeScript interface mismatches for DynastyAssistant component props
 
 ### Technical
-- **ETL Pipeline**: Updated to use global ADP normalization and removed risk score calculations
-- **Database Schema**: Removed riskScore field from ValueDaily model
+- **ETL Pipeline**: Implemented logistic ADP normalization and detailed age curves; removed projection and risk computations
+- **Database Schema**: Dropped projectionScore and riskScore fields from ValueDaily model
 - **Build Scripts**: Enhanced package.json scripts for better Prisma handling and error recovery
 - **API Integration**: Improved Sleeper API roster processing with fallback bench player calculation
 
@@ -59,7 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Dynasty Value Algorithm Improvements
 - **ADP Value Preservation**: Removed normalization to preserve original ADP meaning (1 = most valuable)
 - **Market Value Calculation**: Direct conversion from ADP to 0-100 scale where 1st pick = 100
-- **Projection Score**: Now directly based on market value for more accurate dynasty rankings
 - **Formula Accuracy**: Better reflects real-world draft value and market sentiment
 
 ### Critical Bug Fixes

--- a/ETL_FIX_SUMMARY.md
+++ b/ETL_FIX_SUMMARY.md
@@ -96,7 +96,7 @@ The fix ensures the ETL will:
 - **Coverage**: 1% → 100% of fantasy-relevant players with complete data
 - **Efficiency**: 11,161 → ~6,800 players processed (excludes age-deficient players)
 - **Quality**: 0 failed calculations from data-incomplete players
-- **Data Integrity**: 100% of processed players have market, projection, age, and risk scores
+- **Data Integrity**: 100% of processed players have market and age scores
 - **Performance**: Faster ETL completion with focused processing and no calculation failures
 
 This fix transforms the dynasty fantasy football system from having only 94 players with values to comprehensive coverage of all ~6,800 fantasy-relevant players with complete data, ensuring 100% calculation success rate.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A comprehensive fantasy football dynasty league management application with adva
 
 ### 🔥 Dynasty Values System
 - **Daily ETL Pipeline** - Automated player data collection and processing from Sleeper API
-- **Composite Dynasty Scoring** - Market data + projections + age curves + risk factors (0-100 scale)
+- **Composite Dynasty Scoring** - Market data blended with age curves on a 0-100 scale
 - **Position-Based Normalization** - Fair comparisons across QB, RB, WR, TE, K, DEF
 - **Trend Analysis** - 7-day and 30-day value movement tracking with momentum indicators
 - **Real-Time Rankings** - Live dynasty player valuations updated daily at 06:00 UTC
@@ -102,7 +102,7 @@ curl http://localhost:3000/api/cron/dynasty
 ## 🏈 Dynasty Features Deep Dive
 
 ### Player Valuations
-- **Composite Dynasty Scores** (0-100 scale) combining market, projections, age, and risk
+- **Composite Dynasty Scores** (0-100 scale) combining market data and age curves
 - **Position-Specific Age Curves** accounting for different career arcs
 - **Market Sentiment Analysis** from Sleeper ADP trending data
 - **Trend Indicators** showing 7-day and 30-day value momentum
@@ -110,9 +110,8 @@ curl http://localhost:3000/api/cron/dynasty
 ### Scoring Formula
 ```typescript
 dynastyValue = (
-  marketValue * 0.5 +      // ADP-based market sentiment
-  projectionScore * 0.25 +  // Expected performance
-  ageScore * 0.25          // Age-adjusted value  
+  marketValue * 0.75 +      // ADP-based market sentiment
+  ageScore * 0.25          // Age-adjusted value
 )
 ```
 

--- a/docs/DYNASTY_VALUES.md
+++ b/docs/DYNASTY_VALUES.md
@@ -13,9 +13,7 @@ The Dynasty Values system was built to solve a critical problem in fantasy footb
 ### The Solution
 A comprehensive scoring system that combines:
 1. **Market sentiment** (what people are actually doing - ADP data)
-2. **Projection-based value** (expected performance)
-3. **Age-adjusted scoring** (position-specific career curves)
-4. **Risk assessment** (injury history, contract situations)
+2. **Age-adjusted scoring** (position-specific career curves)
 
 This creates a single, comparable dynasty value (0-100 scale) for every NFL player, updated daily.
 
@@ -38,16 +36,13 @@ Sleeper API → Raw Data → Normalization → Age Adjustment → Composite Scor
    - Captures player metadata: position, team, age, injury status
 
 2. **Data Transformation**
-   - **Global ADP normalization**: ADP values are normalized across all positions (0-100 scale, inverted since lower ADP = higher value)
+   - **Logistic ADP normalization**: ADP values are normalized across all positions (0-100 scale using a logistic curve so top players approach but do not hit 100)
    - **Age curve application**: Each position has different peak ages and decline rates
-   - **Projection calculation**: Combines market data with expected performance
-   - **Risk scoring**: Currently simplified (95/100), designed for future injury/contract analysis
 
 3. **Composite Scoring Formula**
    ```typescript
    dynastyValue = (
-     marketValue * 0.5 +      // What the market thinks (ADP-based)
-     projectionScore * 0.25 +  // Expected performance
+     marketValue * 0.75 +      // What the market thinks (ADP-based)
      ageScore * 0.25          // Age-adjusted value
    )
    ```
@@ -108,7 +103,6 @@ model ValueDaily {
   asOfDate        DateTime
   playerId        String
   marketValue     Float?   // Normalized market score (0-100)
-  projectionScore Float?   // Expected performance score
   ageScore        Float?   // Age-adjusted score
   dynastyValue    Float?   // Final composite score
   trend7d         Float?   // 7-day trend delta
@@ -329,8 +323,8 @@ npx prisma studio
 ## Technical Debt & Known Limitations
 
 ### Current Limitations
-1. **Risk Score**: Simplified to 95/100, needs injury/contract data
-2. **Projection Source**: Using market-derived projections, not expert consensus
+1. **Risk Score**: Not yet implemented
+2. **Projection Component**: Currently omitted; future versions may integrate expert projections
 3. **Position Eligibility**: Single position only, no multi-position players
 4. **Rookie Integration**: New players may not have sufficient ADP data
 

--- a/prisma/migrations/20250501120000_remove_projection_risk/migration.sql
+++ b/prisma/migrations/20250501120000_remove_projection_risk/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "public"."ValueDaily"
+  DROP COLUMN IF EXISTS "projectionScore",
+  DROP COLUMN IF EXISTS "riskScore";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,9 +89,7 @@ model ValueDaily {
   asOfDate        DateTime
   playerId        String
   marketValue     Float?  // 0–100 after normalization
-  projectionScore Float?
   ageScore        Float?
-  riskScore       Float?
   dynastyValue    Float?
   trend7d         Float?
   trend30d        Float?

--- a/scripts/analyze-failed-players.mjs
+++ b/scripts/analyze-failed-players.mjs
@@ -24,18 +24,17 @@ async function analyzeFailedPlayers() {
     // Analyze positions
     const positionCounts = {};
     const positionWithNullData = {};
-    
+
     for (const record of failedPlayers) {
       const pos = record.player.pos;
       if (!positionCounts[pos]) {
         positionCounts[pos] = 0;
-        positionWithNullData[pos] = { market: 0, projection: 0, age: 0 };
+        positionWithNullData[pos] = { market: 0, age: 0 };
       }
-      
+
       positionCounts[pos]++;
-      
+
       if (record.marketValue === null) positionWithNullData[pos].market++;
-      if (record.projectionScore === null) positionWithNullData[pos].projection++;
       if (record.ageScore === null) positionWithNullData[pos].age++;
     }
 
@@ -43,7 +42,7 @@ async function analyzeFailedPlayers() {
     for (const [pos, count] of Object.entries(positionCounts)) {
       const nullData = positionWithNullData[pos];
       console.log(`   ${pos}: ${count} players`);
-      console.log(`     Market null: ${nullData.market}, Projection null: ${nullData.projection}, Age null: ${nullData.age}`);
+      console.log(`     Market null: ${nullData.market}, Age null: ${nullData.age}`);
     }
 
     // Analyze age patterns
@@ -79,20 +78,17 @@ async function analyzeFailedPlayers() {
     const dataPatterns = {
       'all_null': 0,
       'market_only': 0,
-      'projection_only': 0,
       'age_only': 0,
       'partial_data': 0
     };
 
     for (const record of failedPlayers) {
       const hasMarket = record.marketValue !== null;
-      const hasProjection = record.projectionScore !== null;
       const hasAge = record.ageScore !== null;
-      
-      if (!hasMarket && !hasProjection && !hasAge) dataPatterns['all_null']++;
-      else if (hasMarket && !hasProjection && !hasAge) dataPatterns['market_only']++;
-      else if (!hasMarket && hasProjection && !hasAge) dataPatterns['projection_only']++;
-      else if (!hasMarket && !hasProjection && hasAge) dataPatterns['age_only']++;
+
+      if (!hasMarket && !hasAge) dataPatterns['all_null']++;
+      else if (hasMarket && !hasAge) dataPatterns['market_only']++;
+      else if (!hasMarket && hasAge) dataPatterns['age_only']++;
       else dataPatterns['partial_data']++;
     }
 
@@ -110,9 +106,7 @@ async function analyzeFailedPlayers() {
       const record = failedPlayers[i];
       console.log(`\n   ${record.player.name} (${record.player.pos}, Age: ${record.player.ageYears || 'N/A'}, Team: ${record.player.team || 'N/A'})`);
       console.log(`     Market: ${record.marketValue}`);
-      console.log(`     Projection: ${record.projectionScore}`);
       console.log(`     Age Score: ${record.ageScore}`);
-      console.log(`     Risk Score: ${record.riskScore}`);
     }
 
     // Check if there are any patterns in team or specific IDs

--- a/scripts/analyze-position-distribution.mjs
+++ b/scripts/analyze-position-distribution.mjs
@@ -45,9 +45,7 @@ async function analyzePositionDistribution() {
         name: value.player.name,
         dynastyValue: value.dynastyValue,
         marketValue: value.marketValue,
-        projectionScore: value.projectionScore,
-        ageScore: value.ageScore,
-        riskScore: value.riskScore
+        ageScore: value.ageScore
       });
     }
 
@@ -55,9 +53,7 @@ async function analyzePositionDistribution() {
     for (const [pos, players] of Object.entries(positionGroups)) {
       const dynastyValues = players.map(p => p.dynastyValue);
       const marketValues = players.map(p => p.marketValue).filter(v => v !== null);
-      const projectionScores = players.map(p => p.projectionScore).filter(v => v !== null);
       const ageScores = players.map(p => p.ageScore).filter(v => v !== null);
-      const riskScores = players.map(p => p.riskScore).filter(v => v !== null);
 
       console.log(`🏈 ${pos} Position (${players.length} players):`);
       console.log(`   Dynasty Values:`);
@@ -71,13 +67,6 @@ async function analyzePositionDistribution() {
         console.log(`     Min: ${Math.min(...marketValues).toFixed(2)}`);
         console.log(`     Max: ${Math.max(...marketValues).toFixed(2)}`);
         console.log(`     Mean: ${(marketValues.reduce((a, b) => a + b, 0) / marketValues.length).toFixed(2)}`);
-      }
-
-      if (projectionScores.length > 0) {
-        console.log(`   Projection Scores:`);
-        console.log(`     Min: ${Math.min(...projectionScores).toFixed(2)}`);
-        console.log(`     Max: ${Math.max(...projectionScores).toFixed(2)}`);
-        console.log(`     Mean: ${(projectionScores.reduce((a, b) => a + b, 0) / projectionScores.length).toFixed(2)}`);
       }
 
       if (ageScores.length > 0) {

--- a/scripts/analyze-remaining-players.mjs
+++ b/scripts/analyze-remaining-players.mjs
@@ -45,17 +45,15 @@ async function analyzeRemainingPlayers() {
       
       // Get their ValueDaily records to see what's missing
       const remainingValueRecords = await prisma.valueDaily.findMany({
-        where: { 
+        where: {
           playerId: { in: remainingPlayerIds },
           asOfDate: new Date('2025-01-01')
         },
-        select: { 
-          playerId: true, 
-          marketValue: true, 
-          projectionScore: true, 
-          ageScore: true, 
-          riskScore: true,
-          dynastyValue: true 
+        select: {
+          playerId: true,
+          marketValue: true,
+          ageScore: true,
+          dynastyValue: true
         }
       });
       
@@ -67,9 +65,7 @@ async function analyzeRemainingPlayers() {
         console.log(`\n   ${player.name} (${player.pos}, Age: ${player.ageYears || 'N/A'}, Team: ${player.team || 'N/A'})`);
         if (valueRecord) {
           console.log(`     Market: ${valueRecord.marketValue}`);
-          console.log(`     Projection: ${valueRecord.projectionScore}`);
           console.log(`     Age Score: ${valueRecord.ageScore}`);
-          console.log(`     Risk Score: ${valueRecord.riskScore}`);
           console.log(`     Dynasty Value: ${valueRecord.dynastyValue}`);
         } else {
           console.log(`     ❌ No ValueDaily record found!`);
@@ -80,9 +76,7 @@ async function analyzeRemainingPlayers() {
       console.log(`\n🔍 Field Analysis for Remaining Players:`);
       const fieldAnalysis = {
         noMarketValue: 0,
-        noProjectionScore: 0,
         noAgeScore: 0,
-        noRiskScore: 0,
         noValueDailyRecord: 0
       };
       
@@ -93,9 +87,7 @@ async function analyzeRemainingPlayers() {
           fieldAnalysis.noValueDailyRecord++;
         } else {
           if (valueRecord.marketValue === null) fieldAnalysis.noMarketValue++;
-          if (valueRecord.projectionScore === null) fieldAnalysis.noProjectionScore++;
           if (valueRecord.ageScore === null) fieldAnalysis.noAgeScore++;
-          if (valueRecord.riskScore === null) fieldAnalysis.noRiskScore++;
         }
       }
       

--- a/scripts/check-real-time-status.mjs
+++ b/scripts/check-real-time-status.mjs
@@ -58,7 +58,7 @@ async function checkRealTimeStatus() {
       console.log(`\nSample of failed players (first 5):`);
       for (const record of failedPlayers) {
         console.log(`   ${record.player.name} (${record.player.pos}, Age: ${record.player.ageYears || 'N/A'}, Team: ${record.player.team || 'N/A'})`);
-        console.log(`     Market: ${record.marketValue}, Projection: ${record.projectionScore}, Age: ${record.ageScore}`);
+        console.log(`     Market: ${record.marketValue}, Age: ${record.ageScore}`);
       }
       
       // Check if these failed players actually have ADP data

--- a/scripts/debug-dynasty-simple.mjs
+++ b/scripts/debug-dynasty-simple.mjs
@@ -84,7 +84,7 @@ async function debugDynastySimple() {
 
     for (const record of failedPlayers) {
       console.log(`❌ ${record.player.name} (${record.player.pos}, Age: ${record.player.ageYears || 'N/A'})`);
-      console.log(`   Market: ${record.marketValue}, Projection: ${record.projectionScore}, Age: ${record.ageScore}`);
+      console.log(`   Market: ${record.marketValue}, Age: ${record.ageScore}`);
     }
 
     // Sample some players that succeeded
@@ -104,7 +104,7 @@ async function debugDynastySimple() {
 
     for (const record of successPlayers) {
       console.log(`✅ ${record.player.name} (${record.player.pos}, Age: ${record.player.ageYears || 'N/A'})`);
-      console.log(`   Market: ${record.marketValue}, Projection: ${record.projectionScore}, Age: ${record.ageScore}`);
+      console.log(`   Market: ${record.marketValue}, Age: ${record.ageScore}`);
       console.log(`   Dynasty Value: ${record.dynastyValue}`);
     }
 

--- a/scripts/debug-dynasty-values.mjs
+++ b/scripts/debug-dynasty-values.mjs
@@ -49,24 +49,17 @@ async function debugDynastyValues() {
         // Calculate market value (ADP-based)
         const marketValue = Math.max(0, 100 - ((adp - 1) / (100 - 1)) * 100);
         
-        // Projection score (same as market for now)
-        const projectionScore = marketValue;
-        
         // Age multiplier
         const ageMult = ageMultiplier(player.pos, player.ageYears);
-        const ageScore = Math.min(100, Math.max(0, projectionScore * ageMult));
-        
-        // Risk score
-        const riskScore = 95;
-        
+        const ageScore = Math.round(ageMult * 100);
+
         // Final dynasty value
-        const dynastyValue = composite({ marketValue, projectionScore, ageScore, riskScore });
+        const dynastyValue = composite({ marketValue, ageScore });
 
         console.log(`✅ ${player.name} (${player.pos}, Age: ${player.ageYears || 'N/A'}):`);
         console.log(`   ADP: ${adp} → Market: ${marketValue.toFixed(2)}`);
         console.log(`   Age Mult: ${ageMult.toFixed(3)} → Age Score: ${ageScore.toFixed(2)}`);
         console.log(`   Dynasty Value: ${dynastyValue.toFixed(2)}`);
-        console.log(`   Risk Score: ${riskScore}`);
         console.log("");
 
         validCount++;

--- a/scripts/investigate-etl.mjs
+++ b/scripts/investigate-etl.mjs
@@ -73,7 +73,7 @@ async function investigateETL() {
     console.log(`\n❌ Sample Players Without Dynasty Values:`);
     for (const record of noDynastySample) {
       console.log(`   ${record.player.name} (${record.player.pos}, Age: ${record.player.ageYears || 'N/A'})`);
-      console.log(`     Market: ${record.marketValue}, Projection: ${record.projectionScore}, Age: ${record.ageScore}`);
+      console.log(`     Market: ${record.marketValue}, Age: ${record.ageScore}`);
     }
 
     // Check database locks and connections

--- a/scripts/investigate-specific-players.mjs
+++ b/scripts/investigate-specific-players.mjs
@@ -30,12 +30,10 @@ async function investigateSpecificPlayers() {
           playerId: 'GJ Kinne'
         }
       },
-      select: { 
-        marketValue: true, 
-        projectionScore: true, 
-        ageScore: true, 
-        riskScore: true,
-        dynastyValue: true 
+      select: {
+        marketValue: true,
+        ageScore: true,
+        dynastyValue: true
       }
     });
     console.log("GJ Kinne Dynasty Value:", gjKinneValue);
@@ -66,12 +64,10 @@ async function investigateSpecificPlayers() {
           playerId: 'Ben Tate'
         }
       },
-      select: { 
-        marketValue: true, 
-        projectionScore: true, 
-        ageScore: true, 
-        riskScore: true,
-        dynastyValue: true 
+      select: {
+        marketValue: true,
+        ageScore: true,
+        dynastyValue: true
       }
     });
     console.log("Ben Tate Dynasty Value:", benTateValue);

--- a/src/app/dashboard/league/[id]/page.tsx
+++ b/src/app/dashboard/league/[id]/page.tsx
@@ -69,7 +69,7 @@ interface SleeperPlayer {
     interceptions?: number
     fumbles?: number
   }
-  // Rankings and projections
+  // Rankings
   rank?: number
   rank_position?: number
   rank_ecr?: number

--- a/src/lib/dynasty/ageCurves.ts
+++ b/src/lib/dynasty/ageCurves.ts
@@ -1,21 +1,28 @@
-export function ageMultiplier(position: string, ageYears: number | null): number {
-  if (!ageYears) return 1.0;
+export function ageMultiplier(position: string, age: number | null): number {
+  if (!age) return 1.0;
 
-  const curves: Record<string, { peak: number; decline: number }> = {
-    QB: { peak: 28, decline: 0.02 },
-    RB: { peak: 25, decline: 0.08 },
-    WR: { peak: 27, decline: 0.04 },
-    TE: { peak: 28, decline: 0.03 },
-    K: { peak: 30, decline: 0.01 },
-    DEF: { peak: 26, decline: 0.03 },
-  };
+  switch (position) {
+    case "QB":
+      if (age <= 25) return 0.85 + (age - 20) * 0.03;
+      if (age <= 32) return 1.0;
+      return Math.max(0.3, 1.0 - (age - 32) * 0.08);
 
-  const curve = curves[position] || curves.WR;
-  const ageDiff = ageYears - curve.peak;
-  
-  if (ageDiff <= 0) {
-    return 1.0 + Math.abs(ageDiff) * 0.01;
-  } else {
-    return Math.max(0.3, 1.0 - ageDiff * curve.decline);
+    case "RB":
+      if (age <= 24) return 0.7 + (age - 20) * 0.075;
+      if (age <= 27) return 1.0;
+      return Math.max(0.2, 1.0 - (age - 27) * 0.15);
+
+    case "WR":
+      if (age <= 25) return 0.8 + (age - 20) * 0.04;
+      if (age <= 29) return 1.0;
+      return Math.max(0.4, 1.0 - (age - 29) * 0.1);
+
+    case "TE":
+      if (age <= 26) return 0.75 + (age - 20) * 0.042;
+      if (age <= 30) return 1.0;
+      return Math.max(0.35, 1.0 - (age - 30) * 0.09);
+
+    default:
+      return 1.0; // K, DEF have minimal age impact
   }
 }

--- a/src/lib/dynasty/formula.ts
+++ b/src/lib/dynasty/formula.ts
@@ -1,20 +1,15 @@
 interface ScoreInputs {
   marketValue: number;
-  projectionScore: number;
   ageScore: number;
 }
 
-export function composite({ marketValue, projectionScore, ageScore }: ScoreInputs): number {
+export function composite({ marketValue, ageScore }: ScoreInputs): number {
   const weights = {
-    market: 0.5,
-    projection: 0.25,
+    market: 0.75,
     age: 0.25,
   };
 
-  const weighted = 
-    marketValue * weights.market +
-    projectionScore * weights.projection +
-    ageScore * weights.age;
+  const weighted = marketValue * weights.market + ageScore * weights.age;
 
   return Math.round(weighted * 100) / 100;
 }

--- a/src/lib/dynasty/normalize.ts
+++ b/src/lib/dynasty/normalize.ts
@@ -1,6 +1,7 @@
-export function minMax(value: number, min: number, max: number, invert = false): number {
+export function logistic(value: number, min: number, max: number): number {
   if (min === max) return 50;
-  const normalized = (value - min) / (max - min);
-  const result = invert ? 1 - normalized : normalized;
-  return Math.round(result * 100);
+  const z = (value - min) / (max - min);
+  const k = 10; // controls curve steepness
+  const score = 100 / (1 + Math.exp(k * (z - 0.5)));
+  return Math.round(score * 100) / 100;
 }

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -13,7 +13,7 @@ export const openai = new OpenAI({
 export const DYNASTY_SYSTEM_PROMPT = `You are a Dynasty Fantasy Football Assistant with access to comprehensive player valuations and market data. You help fantasy managers make informed decisions about trades, roster construction, and long-term dynasty strategy.
 
 Key capabilities:
-- Analyze player dynasty values (0-100 scale) based on market data, projections, age curves, and risk factors
+  - Analyze player dynasty values (0-100 scale) based on market data and age curves
 - Evaluate trades using composite scoring across positions
 - Provide position-specific advice accounting for different career arcs (QB peak 28-32, RB peak 24-27, etc.)
 - Recommend long-term roster building strategies


### PR DESCRIPTION
## Summary
- drop projection and risk scoring from dynasty values
- normalize ADP with logistic curve to avoid score saturation
- adopt detailed positional age curves and update docs/schema

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68acc6bcd214832492d704579984c849